### PR TITLE
Add an autoformat script for local development

### DIFF
--- a/autoformat.sh
+++ b/autoformat.sh
@@ -1,0 +1,13 @@
+echo "Discovering sources ..."
+
+RELEVANT_FILES_TO_FORMAT=$(find . -type f \( -name "*.c" -o -name "*.h" -o -name "*.cpp" -o -name "*.hpp" -o -name "*.mm" \) -print -o -path "*/deps" -prune -o -path "*/cmakebuild*" -prune)
+
+if [ -n "$RELEVANT_FILES_TO_FORMAT" ]; then
+	echo "Discovered sources:"
+	echo $RELEVANT_FILES_TO_FORMAT
+
+	echo "Formatting sources ..."
+	clang-format -i --verbose $RELEVANT_FILES_TO_FORMAT
+else
+	echo "NO relevant sources found"
+fi


### PR DESCRIPTION
The clang-format CLI is cumbersome at best, so this will make life a little easier.