### PR TITLE
Disable the SortIncludes setting of clang-format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -90,7 +90,7 @@ PenaltyExcessCharacter: 1000000
 PenaltyReturnTypeOnItsOwnLine: 60
 PointerAlignment: Right
 ReflowComments:  false
-SortIncludes:    true
+SortIncludes:    false
 SortUsingDeclarations: true
 SpaceAfterCStyleCast: false
 SpaceAfterTemplateKeyword: true


### PR DESCRIPTION
That's just not very desirable, as it may mess up multiple include blocks.