### PR TITLE
Fix a deprecation warning originating from webview_eval (Linux only)

### DIFF
--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -27,7 +27,8 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install dependencies
-        run: sudo apt-get update && sudo apt-get install libwebkit2gtk-4.0-dev xvfb -y
+        run: sudo apt-get update && sudo apt-get install libwebkit2gtk-4.0-dev xvfb -y \
+          pkg-config --modversion libwebkit2gtk-4.0-dev
 
       - name: Configure build process
         run: cmake -S . -B cmakebuild

--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -27,8 +27,8 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install dependencies
-        run: sudo apt-get update && sudo apt-get install libwebkit2gtk-4.0-dev xvfb -y \
-          pkg-config --modversion libwebkit2gtk-4.0-dev
+        run: sudo apt-get update && sudo apt-get install libwebkit2gtk-4.0-dev xvfb -y && pkg-config --modversion libwebkit2gtk-4.0-dev
+          
 
       - name: Configure build process
         run: cmake -S . -B cmakebuild

--- a/src/linux/webview_gtk.h
+++ b/src/linux/webview_gtk.h
@@ -121,8 +121,9 @@ public:
   }
 
   void eval(const std::string &js) {
-    webkit_web_view_run_javascript(WEBKIT_WEB_VIEW(m_webview), js.c_str(),
-                                   nullptr, nullptr, nullptr);
+    webkit_web_view_evaluate_javascript(WEBKIT_WEB_VIEW(m_webview), js.c_str(),
+                                        -1, nullptr, nullptr, nullptr, nullptr,
+                                        nullptr);
   }
 
 private:

--- a/src/linux/webview_gtk.h
+++ b/src/linux/webview_gtk.h
@@ -121,9 +121,8 @@ public:
   }
 
   void eval(const std::string &js) {
-    webkit_web_view_evaluate_javascript(WEBKIT_WEB_VIEW(m_webview), js.c_str(),
-                                        -1, nullptr, nullptr, nullptr, nullptr,
-                                        nullptr);
+    webkit_web_view_run_javascript(WEBKIT_WEB_VIEW(m_webview), js.c_str(),
+                                   nullptr, nullptr, nullptr);
   }
 
 private:


### PR DESCRIPTION
Same API, the old one is just somewhat more limited. No effective change since none of the advanced features are even used.